### PR TITLE
Format new lines in embed messages

### DIFF
--- a/src/DiscordAlert.php
+++ b/src/DiscordAlert.php
@@ -20,6 +20,10 @@ class DiscordAlert
         $text = $this->parseNewline($text);
 
         foreach ($embeds as $key => $embed) {
+            if (array_key_exists('description', $embed)) {
+                $embeds[$key]['description'] = $this->parseNewline($embeds[$key]['description']);
+            }
+            
             if (array_key_exists('color', $embed)) {
                 $embeds[$key]['color'] = hexdec(str_replace('#', '', $embed['color'])) ;
             }

--- a/tests/DiscordAlertsTest.php
+++ b/tests/DiscordAlertsTest.php
@@ -64,6 +64,21 @@ it('will convert a newline string (\n) into a PHP_EOL constant', function () {
     });
 });
 
+it('will convert a newline string (\n) into a PHP_EOL constant in embeds as well', function () {
+    config()->set('discord-alerts.webhook_urls.default', 'https://test-domain.com');
+
+    DiscordAlert::message('test \n data', [
+        [
+            'title' => 'Test Embed',
+            'description' => 'This is a test embed.\nI should be on a new line.',
+        ],
+    ]);
+
+    Bus::assertDispatched(function (SendToDiscordChannelJob $job) {
+        return $job->embeds[0]['description'] === "This is a test embed." . PHP_EOL . "I should be on a new line.";
+    });
+});
+
 it('will send a message as well as a embed in just one message', function () {
     config()->set('discord-alerts.webhook_urls.default', 'https://test-domain.com');
 


### PR DESCRIPTION
You are able to use `\n` in the `message` function, but not yet in embeds. This PR adds that functionality.