### PR TITLE
Fix minor markdown typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ You can format your messages with markup. Learn how [in the Discord API docs](ht
 ```php
 use Spatie\DiscordAlerts\Facades\DiscordAlert;
 
-DiscordAlert::message("A message *with some bold statements* and _some italicized text_.");
+DiscordAlert::message("A message **with some bold statements** and _some italicized text_.");
 ```
 
 ### Emoji's


### PR DESCRIPTION
README had singular asterisks as bold, even though it should be double asterisks. This commit fixes that minor issue in the README to avoid confusion.