### PR TITLE
Add Support for Laravel 11.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.1, 8.0]
-        laravel: [10.*, 9.*, 8.*]
+        laravel: [11.*, 10.*, 9.*, 8.*]
         stability: [prefer-stable]
         include:
           - laravel: 8.*
@@ -23,9 +23,11 @@ jobs:
             testbench: ^7.0
           - laravel: 10.*
             testbench: ^8.0
+          - laravel: 11.*
+            testbench: ^9.0
         exclude:
-          - laravel: 10.*
-            php: 8.0
+          - laravel: 11.*
+            php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,6 +26,8 @@ jobs:
           - laravel: 11.*
             testbench: ^9.0
         exclude:
+          - laravel: 10.*
+            php: 8.0
           - laravel: 11.*
             php: 8.0
           - laravel: 11.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,8 @@ jobs:
             testbench: ^9.0
         exclude:
           - laravel: 11.*
+            php: 8.0
+          - laravel: 11.*
             php: 8.1
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -34,12 +34,10 @@
         "nunomaduro/collision": "^5.10|^6.0|^7.0",
         "nunomaduro/larastan": "^1.0|^2.0",
         "orchestra/testbench": "^6.22|^7.0|^8.0|^9.0",
-        "pestphp/pest": "^1.21",
+        "pestphp/pest": "^1.21|^2.0",
         "pestphp/pest-plugin-laravel": "^1.1|^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^8.73|^9.0|^10.0"
+        "illuminate/contracts": "^8.73|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "nunomaduro/collision": "^5.10|^6.0|^7.0",
         "nunomaduro/larastan": "^1.0|^2.0",
-        "orchestra/testbench": "^6.22|^7.0|^8.0",
+        "orchestra/testbench": "^6.22|^7.0|^8.0|^9.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1|^2.0",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,10 @@
         "illuminate/contracts": "^8.73|^9.0|^10.0|^11.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.10|^6.0|^7.0",
+        "nunomaduro/collision": "^5.10|^6.0|^7.0|^8.0",
         "nunomaduro/larastan": "^1.0|^2.0",
         "orchestra/testbench": "^6.22|^7.0|^8.0|^9.0",
-        "pestphp/pest": "^1.21|^2.0",
+        "pestphp/pest": "^1.21|^2.0|^3.0",
         "pestphp/pest-plugin-laravel": "^1.1|^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",


### PR DESCRIPTION
Update dependencies to support Laravel 11.x
Remove PHPUnit because i think its not needed anymore since Pest ist used for the tests.