### PR TITLE
Custom job dispatch connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ return [
      * job to set timeouts, retries, etc...
      */
     'job' => Spatie\DiscordAlerts\Jobs\SendToDiscordChannelJob::class,
+
+    /*
+     * It is possible to specify the queue connection that should be used to send the alert.
+     */
+    'queue_connection' => 'redis',
 ];
 
 ```

--- a/src/Config.php
+++ b/src/Config.php
@@ -41,7 +41,7 @@ class Config
 
     public static function getConnection(): string
     {
-        $connection = config("discord-alerts.connection");
+        $connection = config("discord-alerts.queue_connection");
         if(is_null($connection)) {
             $connection = config("queue.default");
         }

--- a/src/Config.php
+++ b/src/Config.php
@@ -38,4 +38,13 @@ class Config
 
         return $url;
     }
+
+    public static function getConnection(): string
+    {
+        $connection = config("discord-alerts.connection");
+        if(is_null($connection)) {
+            $connection = config("queue.default");
+        }
+        return $connection;
+    }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -42,9 +42,11 @@ class Config
     public static function getConnection(): string
     {
         $connection = config("discord-alerts.queue_connection");
+        
         if(is_null($connection)) {
             $connection = config("queue.default");
         }
+        
         return $connection;
     }
 }

--- a/src/DiscordAlert.php
+++ b/src/DiscordAlert.php
@@ -37,7 +37,7 @@ class DiscordAlert
 
         $job = Config::getJob($jobArguments);
 
-        dispatch($job);
+        dispatch($job)->onConnection('');
     }
 
     private function parseNewline(string $text): string

--- a/src/DiscordAlert.php
+++ b/src/DiscordAlert.php
@@ -37,7 +37,7 @@ class DiscordAlert
 
         $job = Config::getJob($jobArguments);
 
-        dispatch($job)->onConnection('');
+        dispatch($job)->onConnection(Config::getConnection());
     }
 
     private function parseNewline(string $text): string

--- a/tests/DiscordAlertsTest.php
+++ b/tests/DiscordAlertsTest.php
@@ -18,6 +18,17 @@ it('can dispatch a job to send a message to discord using the default webhook ur
     Bus::assertDispatched(SendToDiscordChannelJob::class);
 });
 
+it('can dispatch a job to send a message to discord using the default webhook url and a custom queue', function () {
+    config()->set('discord-alerts.webhook_urls.default', 'https://test-domain.com');
+    config()->set('discord-alerts.queue_connection', 'custom-queue-connection');
+
+    DiscordAlert::message('test-data');
+
+    Bus::assertDispatched(SendToDiscordChannelJob::class, function ($job) {
+        return $job->connection === 'custom-queue-connection';
+    });
+});
+
 it('can dispatch a job to send a message to discord using an alternative webhook url', function () {
     config()->set('discord-alerts.webhook_urls.marketing', 'https://test-domain.com');
 


### PR DESCRIPTION
In this pull request I'm adding the possibility to choose the connection for the job dispatch.
I think this could be useful in projects with multiple connections.

I've also added a sample of usage in the README and a unit test.
