### PR TITLE
Username, avatar, tts webhook functionality.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ return [
 
 ```
 
-**NOTE**: You have to publish the config if you want to add or edit the avatar.
-
 ## Usage
 
 To send a message to Discord, simply call `DiscordAlert::message()` and pass it any message you want.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ return [
     ],
 
     /*
+     * Default avatar is an empty string '' which means it will not be included in the payload.
+     * You can add multiple custom avatars and then specify directly with withAvatar()
+     */
+    'avatar_urls' => [
+        'default' => '',
+    ],
+
+    /*
      * This job will send the message to Discord. You can extend this
      * job to set timeouts, retries, etc...
      */
@@ -67,6 +75,8 @@ return [
 ];
 
 ```
+
+**NOTE**: You have to publish the config if you want to add or edit the avatar.
 
 ## Usage
 
@@ -95,6 +105,15 @@ DiscordAlert::message("You have a new subscriber to the {$newsletter->name} news
 ```
 
 You can also send multiple embeds as one message. Just be careful that you don't hit the limit of Discord.
+
+## Changing webhook username/avatar/tts
+
+Add/change the functions before invoking the message. `DiscordAlert::message()`
+tts is false by default. You can add multiple custom avatars in the config file (same as multiple webhooks).
+
+```php
+DiscordAlert::withUsername('Test')->enableTTS('true')->withAvatar('custom')->message("You have a new subscriber to the {$newsletter->name} newsletter!");
+```
 
 ## Using multiple webhooks
 

--- a/config/discord-alerts.php
+++ b/config/discord-alerts.php
@@ -9,6 +9,14 @@ return [
     ],
 
     /*
+     * Default avatar is an empty string '' which means it will not be included in the payload.
+     * You can add multiple custom avatars and then specify directly with withAvatar()
+     */
+    'avatar_urls' => [
+        'default' => '',
+    ],
+
+    /*
      * This job will send the message to Discord. You can extend this
      * job to set timeouts, retries, etc...
      */

--- a/src/Config.php
+++ b/src/Config.php
@@ -39,11 +39,33 @@ class Config
         return $url;
     }
 
+    public static function getAvatarUrl(string $name): ?string
+    {
+        $url = config("discord-alerts.avatar_urls.{$name}", '');
+    
+        // If the URL is empty, return null (no avatar included in payload)
+        if ($url === '') {
+            return null;
+        }
+    
+        // Validate that it is a proper URL
+        if (!filter_var($url, FILTER_VALIDATE_URL)) {
+            throw new \InvalidArgumentException("Invalid avatar URL: {$url}");
+        }
+    
+        // Optional: Enforce HTTPS only
+        if (!preg_match('/^https:\/\//', $url)) {
+            throw new \InvalidArgumentException("Invalid avatar URL: {$url}. Must use HTTPS.");
+        }
+    
+        return $url;
+    }    
+
     public static function getConnection(): string
     {
         $connection = config("discord-alerts.queue_connection");
 
-        if (is_null($connection)) {
+        if(is_null($connection)) {
             $connection = config("queue.default");
         }
 

--- a/src/DiscordAlert.php
+++ b/src/DiscordAlert.php
@@ -5,30 +5,53 @@ namespace Spatie\DiscordAlerts;
 class DiscordAlert
 {
     protected string $webhookUrlName = 'default';
-
-    protected int $delay = 0; // minutes
+    protected int $delay = 0;
+    protected ?string $username = null;
+    protected bool $tts = false;
+    protected ?string $avatarUrl = null;
 
     public function to(string $webhookUrlName): self
     {
         $this->webhookUrlName = $webhookUrlName;
         $this->delay = 0;
-
         return $this;
     }
 
-    public function delayMinutes(int $minutes = 0)
+    public function delayMinutes(int $minutes = 0): self
     {
         $this->delay += $minutes;
-
         return $this;
     }
 
-    public function delayHours(int $hours = 0)
+    public function delayHours(int $hours = 0): self
     {
         $this->delay += $hours * 60;
-
         return $this;
     }
+
+    public function withUsername(string $username): self
+    {
+        // Validate username: Allow letters, numbers, spaces, underscores, and dashes
+        if (!preg_match('/^[a-zA-Z0-9 _-]{1,32}$/', $username)) {
+            throw new \InvalidArgumentException("Invalid username. Allowed: letters, numbers, spaces, underscores, dashes (max 32 chars).");
+        }
+
+        $this->username = $username;
+        return $this;
+    }
+
+    public function enableTTS(bool $enabled = false): self
+    {
+        $this->tts = $enabled;
+        return $this;
+    }
+
+    public function withAvatar(string $avatarName): self
+    {
+        $this->avatarUrl = Config::getAvatarUrl($avatarName);
+        return $this;
+    }
+    
 
     public function message(string $text, array $embeds = []): void
     {
@@ -42,15 +65,24 @@ class DiscordAlert
             }
 
             if (array_key_exists('color', $embed)) {
-                $embeds[$key]['color'] = hexdec(str_replace('#', '', $embed['color'])) ;
+                $embeds[$key]['color'] = hexdec(str_replace('#', '', $embed['color']));
             }
         }
 
         $jobArguments = [
             'text' => $text,
             'webhookUrl' => $webhookUrl,
+            'tts' => $this->tts,
             'embeds' => $embeds,
         ];
+
+        if (!empty($this->username)) {
+            $jobArguments['username'] = $this->username;
+        }
+
+        if (!empty($this->avatarUrl)) {
+            $jobArguments['avatar_url'] = $this->avatarUrl;
+        }
 
         $job = Config::getJob($jobArguments);
 

--- a/src/DiscordAlert.php
+++ b/src/DiscordAlert.php
@@ -82,6 +82,11 @@ class DiscordAlert
 
         if (!empty($this->avatarUrl)) {
             $jobArguments['avatar_url'] = $this->avatarUrl;
+        } else {
+            $defaultAvatar = Config::getAvatarUrl('default');
+            if (!empty($defaultAvatar)) {
+                $jobArguments['avatar_url'] = $defaultAvatar;
+            }
         }
 
         $job = Config::getJob($jobArguments);

--- a/src/Jobs/SendToDiscordChannelJob.php
+++ b/src/Jobs/SendToDiscordChannelJob.php
@@ -24,6 +24,9 @@ class SendToDiscordChannelJob implements ShouldQueue
     public function __construct(
         public string $text,
         public string $webhookUrl,
+        public ?string $username = null,
+        public bool $tts = false,
+        public ?string $avatar_url = null,
         public array|null $embeds = null
     ) {
     }
@@ -32,9 +35,18 @@ class SendToDiscordChannelJob implements ShouldQueue
     {
         $payload = [
             'content' => $this->text,
+            'tts' => $this->tts,
         ];
 
-        if (! blank($this->embeds)) {
+        if (!empty($this->username)) {
+            $payload['username'] = $this->username;
+        }
+
+        if (!empty($this->avatar_url)) {
+            $payload['avatar_url'] = $this->avatar_url;
+        }
+
+        if (!empty($this->embeds)) {
             $payload['embeds'] = $this->embeds;
         }
 


### PR DESCRIPTION
I have one discord channel dedicated to notifications, instead of creating custom webhooks (with different names/avatars) for the same channel I wanted to add the functionality to the code directly to customize the avatar/username so its clear which project is sending a notification to the channel.

I though others might find the additional settings useful.
This is my first time contributing to anything on github so hopefully im not breaking any taboos. I did my best 🥹 