### PR TITLE
Add support voor Laravel 12 and drop support for old Laravel versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,32 +8,22 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        php: [8.2, 8.1, 8.0]
-        laravel: [11.*, 10.*, 9.*, 8.*]
-        stability: [prefer-stable]
+        php: [8.4, 8.3, 8.2]
+        laravel: [10.*, 11.*, 12.*]
+        dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 8.*
-            testbench: ^6.23
-          - laravel: 9.*
-            testbench: ^7.0
           - laravel: 10.*
             testbench: ^8.0
           - laravel: 11.*
             testbench: ^9.0
-        exclude:
-          - laravel: 10.*
-            php: 8.0
-          - laravel: 11.*
-            php: 8.0
-          - laravel: 11.*
-            php: 8.1
+          - laravel: 12.*
+            testbench: ^10.0
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
     steps:
       - name: Checkout code
@@ -46,7 +36,7 @@ jobs:
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
-      - name: Setup problem matchers
+      - name: Setup Problem Matches
         run: |
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -54,7 +44,8 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer remove "larastan/larastan" --dev --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Execute tests
         run: vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,16 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^8.73|^9.0|^10.0|^11.0"
+        "illuminate/contracts": "^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "nunomaduro/collision": "^5.10|^6.0|^7.0|^8.0",
-        "nunomaduro/larastan": "^1.0|^2.0",
-        "orchestra/testbench": "^6.22|^7.0|^8.0|^9.0",
-        "pestphp/pest": "^1.21|^2.0|^3.0",
-        "pestphp/pest-plugin-laravel": "^1.1|^2.0",
-        "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
+        "larastan/larastan": "^2.0|^3.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "pestphp/pest": "^2.28|^3.5",
+        "phpstan/extension-installer": "^1.3.1",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {


### PR DESCRIPTION
To enhance the spatie/laravel-discord-alerts package, this pull request introduces support for Laravel 12, maintains compatibility with Laravel 10, and updates the minimum PHP requirement to version 8.2. Support for older, unsupported Laravel versions has been removed to streamline maintenance and ensure compatibility with the latest framework features.

Key Updates:

**Added Support for Laravel 12:**
Updated the illuminate/contracts dependency to include version ^12.0.

**Maintained Support for Laravel 10:**
Retained compatibility with Laravel 10, acknowledging its end-of-life status as of February 4th, 2025.  ￼

**Dropped Support for Unsupported Laravel Versions:**
Removed compatibility for Laravel versions that have reached end-of-life, specifically versions 9 and below.

**Increased Minimum PHP Version Requirement:**
Set the minimum PHP version to 8.2, aligning with Laravel 12’s requirements.  ￼
