### PR TITLE
[QUEUE] Specify queue name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ return [
      * It is possible to specify the queue connection that should be used to send the alert.
      */
     'queue_connection' => 'redis',
+    
+     /*
+     * The queue name that should be used to send the alert. Only supported for drivers
+     * that allow multiple queues (e.g., redis, database, beanstalkd). Ignored for sync and null drivers.
+     */
+     'queue' => env('DISCORD_ALERT_QUEUE', 'default'),
 ];
 
 ```

--- a/config/discord-alerts.php
+++ b/config/discord-alerts.php
@@ -21,4 +21,10 @@ return [
      * job to set timeouts, retries, etc...
      */
     'job' => Spatie\DiscordAlerts\Jobs\SendToDiscordChannelJob::class,
+
+    /*
+    * The queue name that should be used to send the alert. Only supported for drivers
+    * that allow multiple queues (e.g., redis, database, beanstalkd). Ignored for sync and null drivers.
+    */
+    'queue' => env('DISCORD_ALERT_QUEUE', 'default'),
 ];

--- a/src/Config.php
+++ b/src/Config.php
@@ -69,4 +69,15 @@ class Config
 
         return $connection;
     }
+
+    public static function getQueue(): ?string
+    {
+        $queueName = config("discord-alerts.queue");
+
+        if (! $queueName) {
+            return null;
+        }
+
+        return $queueName;
+    }
 }

--- a/src/DiscordAlert.php
+++ b/src/DiscordAlert.php
@@ -94,6 +94,10 @@ class DiscordAlert
 
         $job = Config::getJob($jobArguments);
 
+        if ($queue = Config::getQueue()) {
+            $job->onQueue($queue);
+        }
+
         dispatch($job)->delay(now()->addMinutes($this->delay))->onConnection(Config::getConnection());
     }
 

--- a/tests/DiscordAlertsTest.php
+++ b/tests/DiscordAlertsTest.php
@@ -31,6 +31,27 @@ it('can dispatch a job to send a message to discord using the default webhook ur
     });
 });
 
+it('can dispatch a job to send a message to discord using the default webhook url and a custom queue name', function () {
+    config()->set('discord-alerts.webhook_urls.default', 'https://test-domain.com');
+    config()->set('discord-alerts.queue', 'custom-queue-name');
+
+    DiscordAlert::message('test-data');
+
+    Bus::assertDispatched(SendToDiscordChannelJob::class, function ($job) {
+        return $job->queue === 'custom-queue-name';
+    });
+});
+
+it('can dispatch a job to send a message to discord using the default webhook url and the default queue name', function () {
+    config()->set('discord-alerts.webhook_urls.default', 'https://test-domain.com');
+
+    DiscordAlert::message('test-data');
+
+    Bus::assertDispatched(SendToDiscordChannelJob::class, function ($job) {
+        return $job->queue === 'default';
+    });
+});
+
 it('can dispatch a job to send a message to discord using an alternative webhook url', function () {
     config()->set('discord-alerts.webhook_urls.marketing', 'https://test-domain.com');
 


### PR DESCRIPTION
Hello, 

I'm creating this pull request, as I ran against the necessity of specifying the queue name in order to dispatch the jobs in a low priority queue.

I've added documentation in the README.md and updated the config file.

(BTW there is a mismatch between the READ.me and actual config file discovered with the command : `php artisan vendor:publish --tag="discord-alerts-config"`). I think that the config file lacks the queue_connection key)
