### PR TITLE
Laravel 13.x Compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,21 +12,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.4, 8.3, 8.2]
-        laravel: [10.*, 11.*, 12.*, 13.*]
+        php: [8.4]
+        laravel: [12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: ^8.0
-          - laravel: 11.*
-            testbench: ^9.0
           - laravel: 12.*
             testbench: ^10.0
           - laravel: 13.*
             testbench: ^11.0
-        exclude:
-          - laravel: 13.*
-            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.4, 8.3, 8.2]
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -22,6 +22,11 @@ jobs:
             testbench: ^9.0
           - laravel: 12.*
             testbench: ^10.0
+          - laravel: 13.*
+            testbench: ^11.0
+        exclude:
+          - laravel: 13.*
+            php: 8.2
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -28,13 +28,13 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^10.0|^11.0|^12.0"
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.10|^6.0|^7.0|^8.0",
+        "nunomaduro/collision": "^5.10|^6.0|^7.0|^8.0|^9.0",
         "larastan/larastan": "^2.0|^3.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
-        "pestphp/pest": "^2.28|^3.5",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^2.28|^3.5|^4.0",
         "phpstan/extension-installer": "^1.3.1",
         "spatie/laravel-ray": "^1.26"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,15 +26,15 @@
         }
     ],
     "require": {
-        "php": "^8.2",
-        "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0"
+        "php": "^8.4",
+        "spatie/laravel-package-tools": "^1.93.0",
+        "illuminate/contracts": "^12.0|^13.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.10|^6.0|^7.0|^8.0|^9.0",
-        "larastan/larastan": "^2.0|^3.0",
-        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
-        "pestphp/pest": "^2.28|^3.5|^4.0",
+        "nunomaduro/collision": "^8.0|^9.0",
+        "larastan/larastan": "^3.0",
+        "orchestra/testbench": "^10.0|^11.0",
+        "pestphp/pest": "^4.0",
         "phpstan/extension-installer": "^1.3.1",
         "spatie/laravel-ray": "^1.26"
     },


### PR DESCRIPTION
## Summary

- Bump `illuminate/contracts` constraint to include `^13.0`
- Bump `orchestra/testbench` constraint to include `^11.0`
- Bump `nunomaduro/collision` constraint to include `^9.0`
- Bump `pestphp/pest` constraint to include `^4.0`
- Update CI matrix to test against Laravel 13 (excluding PHP 8.2)

## Test plan

- [x] CI passes for Laravel 10, 11, 12, and 13 matrix