### PR TITLE
Fix PHPStan config on main

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,9 +5,6 @@ parameters:
     level: 8
     paths:
         - src
-        - config
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
-

--- a/src/Config.php
+++ b/src/Config.php
@@ -10,6 +10,9 @@ use Spatie\DiscordAlerts\Jobs\SendToDiscordChannelJob;
 
 class Config
 {
+    /**
+     * @param array<string, mixed> $arguments
+     */
     public static function getJob(array $arguments): SendToDiscordChannelJob
     {
         $jobClass = config('discord-alerts.job');

--- a/src/DiscordAlert.php
+++ b/src/DiscordAlert.php
@@ -59,6 +59,9 @@ class DiscordAlert
         return $this;
     }
 
+    /**
+     * @param array<int, array<string, mixed>> $embeds
+     */
     public function message(string $text, array $embeds = []): void
     {
         $webhookUrl = Config::getWebhookUrl($this->webhookUrlName);

--- a/src/Facades/DiscordAlert.php
+++ b/src/Facades/DiscordAlert.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static self to(string $text)
  * @method static self delayMinutes(int $minutes)
  * @method static self delayHours(int $hours)
- * @method static void message(string $text, array $embeds = null)
+ * @method static void message(string $text, array<int, array<string, mixed>> $embeds = [])
  *
  * @see \Spatie\DiscordAlerts\DiscordAlert
  */

--- a/src/Jobs/SendToDiscordChannelJob.php
+++ b/src/Jobs/SendToDiscordChannelJob.php
@@ -21,6 +21,9 @@ class SendToDiscordChannelJob implements ShouldQueue
      */
     public int $maxExceptions = 3;
 
+    /**
+     * @param array<int, array<string, mixed>>|null $embeds
+     */
     public function __construct(
         public string $text,
         public string $webhookUrl,


### PR DESCRIPTION
This removes a stale PHPStan 1 config option and adds the missing array value types that PHPStan 2 now requires.

It also stops analysing the published config file, where env() usage is expected.

Closes the failing PHPStan check on main.