### PR TITLE
Add PHP 8.3 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.4]
+        php: [8.3, 8.4]
         laravel: [12.*, 13.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.3",
         "spatie/laravel-package-tools": "^1.93.0",
         "illuminate/contracts": "^12.0|^13.0"
     },


### PR DESCRIPTION
## Summary

- Change `php` requirement from `^8.4` back to `^8.3`
- Add PHP 8.3 to the CI test matrix

## Test plan

- [ ] CI passes for PHP 8.3 and 8.4 with Laravel 12 and 13